### PR TITLE
Fix Bootstrap import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import App from './App';
 import './index.css';
 
 import $ from 'jquery';
-import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap/dist/css/bootstrap.css';
 
 // Bootstrap JS relies on a global varaible.
 // In ES6, all imports are hoisted to the top of the file
@@ -13,7 +13,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 // variable. This is why we have to use CommonJS require()
 // here since it doesn't have the hoisting behavior.
 window.jQuery = $;
-require('bootstrap/dist/js/bootstrap.min.js');
+require('bootstrap');
 
 ReactDOM.render(
   <App />,

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,16 @@ import App from './App';
 import './index.css';
 
 import $ from 'jquery';
-
-window.jQuery = window.$ = $;
-
 import 'bootstrap/dist/css/bootstrap.min.css';
-import 'bootstrap/dist/js/bootstrap.min.js';
+
+// Bootstrap JS relies on a global varaible.
+// In ES6, all imports are hoisted to the top of the file
+// so if we used `import` to import Bootstrap, it would
+// execute earlier than we have assigned the global
+// variable. This is why we have to use CommonJS require()
+// here since it doesn't have the hoisting behavior.
+window.jQuery = $;
+require('bootstrap/dist/js/bootstrap.min.js');
 
 ReactDOM.render(
   <App />,


### PR DESCRIPTION
Bootstrap JS relies on `jQuery` being a global variable. (That’s pretty weird but I guess that’s how it works.)

In ES6, all imports are hoisted to the top of the file so if we used `import` to import Bootstrap, it would execute earlier than we have assigned the global variable.

This is why we have to use CommonJS `require()` here since it doesn't get hoisted. This lets us assign the variable earlier.

I also changed the imports to use unminified version since we minify everything as a build step anyway.
